### PR TITLE
Add tvOS identifiers

### DIFF
--- a/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
+++ b/pkgs/os-specific/darwin/xcode/sdk-pkgs.nix
@@ -46,6 +46,10 @@ rec {
       echo "-platform_version ios-simulator ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
     '' + lib.optionalString (sdk.platform == "iPhoneOS") ''
       echo "-platform_version ios ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
+    '' + lib.optionalString (sdk.platform == "AppleTVOS") ''
+      echo "-platform_version tvos ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
+    '' + lib.optionalString (sdk.platform == "AppleTVSimulator") ''
+      echo "-platform_version tvos-simulator ${minSdkVersion} ${sdk.version}" >> $out/nix-support/libc-ldflags
     '';
   };
 
@@ -70,6 +74,10 @@ rec {
       echo "-mios-simulator-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
     '' + lib.optionalString (sdk.platform == "iPhoneOS") ''
       echo "-miphoneos-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
+    '' + lib.optionalString (sdk.platform == "AppleTVSimulator") ''
+      echo "-mappletvsimulator-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
+    '' + lib.optionalString (sdk.platform == "AppleTVOS") ''
+      echo "-mappletvos-version-min=${minSdkVersion}" >> $out/nix-support/cc-cflags
     '';
   }) // {
     inherit sdk;


### PR DESCRIPTION
###### Motivation for this change


###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

